### PR TITLE
Utilize @MainActor to fix @Sendable warnings

### DIFF
--- a/AR Demo/View Models/CommitDetailsViewModel.swift
+++ b/AR Demo/View Models/CommitDetailsViewModel.swift
@@ -1,7 +1,8 @@
 import ARNetworking
 import Foundation
 
-class CommitDetailsViewModel: ObservableObject {
+@MainActor
+final class CommitDetailsViewModel: ObservableObject {
     @Published var commit: CommitDetails?
     @Published var showError = false
 
@@ -36,15 +37,11 @@ extension CommitDetailsViewModel {
                 let commitDetails = try await request(NetworkUtils.mapResults)
                 appManager.updateLoading(false)
 
-                DispatchQueue.main.async { [weak self] in
-                    self?.commit = commitDetails
-                }
+                self.commit = commitDetails
             } catch {
                 appManager.updateLoading(false)
 
-                DispatchQueue.main.async { [weak self] in
-                    self?.error = error
-                }
+                self.error = error
             }
         }
     }

--- a/AR Demo/View Models/RepositoryDetailsViewModel.swift
+++ b/AR Demo/View Models/RepositoryDetailsViewModel.swift
@@ -1,6 +1,7 @@
 import ARNetworking
 import Foundation
 
+@MainActor
 class RepositoryDetailsViewModel: ObservableObject {
     @Published var commits = [Commit]()
     @Published var showError = false
@@ -39,15 +40,11 @@ extension RepositoryDetailsViewModel {
                 let commits = try await request(NetworkUtils.mapResults)
                 appManager.updateLoading(false)
 
-                DispatchQueue.main.async { [weak self] in
-                    self?.commits = commits
-                }
+                self.commits = commits
             } catch let error as NSError {
                 appManager.updateLoading(false)
 
-                DispatchQueue.main.async { [weak self] in
-                    self?.error = error
-                }
+                self.error = error
             }
         }
     }

--- a/AR Demo/View Models/RepositoryListViewModel.swift
+++ b/AR Demo/View Models/RepositoryListViewModel.swift
@@ -1,6 +1,7 @@
 import ARNetworking
 import Foundation
 
+@MainActor
 class RepositoryListViewModel: ObservableObject {
     @Published var repositories = [Repository]()
     @Published var showError = false
@@ -34,15 +35,11 @@ extension RepositoryListViewModel {
                 let repositories = try await request(NetworkUtils.mapResults)
                 appManager.updateLoading(false)
 
-                DispatchQueue.main.async { [weak self] in
-                    self?.repositories = repositories
-                }
+                self.repositories = repositories
             } catch let error as NSError {
                 appManager.updateLoading(false)
 
-                DispatchQueue.main.async { [weak self] in
-                    self?.error = error
-                }
+                self.error = error
             }
         }
     }

--- a/Local Packages/ARNetworking/Tests/ARNetworkingTests/NetworkingManagerTests.swift
+++ b/Local Packages/ARNetworking/Tests/ARNetworkingTests/NetworkingManagerTests.swift
@@ -120,12 +120,12 @@ final class NetworkingManagerTests: XCTestCase {
     }
 
     func testFetchCommitDetailsSuccess() async throws {
-        MockURLProtocol.requestErrorMode = success
+        MockURLProtocol.requestErrorMode = .success
         let result = await networkingManager.fetchCommitDetails(commitUrl: "https://api.github.com/repos/atomicrobot/CarbonAndroid/git/commits/thisisafakecommit")
 
         switch result {
         case .success(let data):
-            let commit = try TestJSONDecoder().decode(CommitD, from: data)
+            let commit = try TestJSONDecoder().decode(CommitDetails.self, from: data)
             XCTAssertNotNil(commit)
         case .failure:
             XCTFail()


### PR DESCRIPTION
Xcode 14.3 turned some new warnings on by default with @Sendable objects. We can address these warnings by using @MainActor on our view models that are doing this asynchronously 